### PR TITLE
CMake changes and bugfix for hadronic decays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,9 @@ message(STATUS "Found ROOT version: " ${ROOT_VERSION})
 #---Define useful ROOT functions and macros (e.g. ROOT_GENERATE_DICTIONARY)
 include(${ROOT_USE_FILE})
 
+# explicitly tell the linker to use the EG library to resolve linker problems with TDatabasePDG::Instance()
+set(DEFAULT_LINKER_FLAGS "-lEG")
+
 ##LIST(APPEND INCL_FILES ${PHDRS})
 
 #include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,11 @@ MESSAGE( STATUS "INCL_FILES: " ${INCL_FILES} )
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{ROOTSYS}/etc/cmake)
 
 #---Locate the ROOT package and defines a number of variables (e.g. ROOT_INCLUDE_DIRS)
-find_package(ROOT REQUIRED COMPONENTS RIO Net)
+find_package(ROOT "6.00" REQUIRED COMPONENTS RIO Net)
+if(ROOT_VERSION LESS 6.00)
+	message(FATAL_ERROR "The required ROOT version has to be at least 6.00, found " ${ROOT_VERSION})
+endif()
+message(STATUS "Found ROOT version: " ${ROOT_VERSION})
 
 #---Define useful ROOT functions and macros (e.g. ROOT_GENERATE_DICTIONARY)
 include(${ROOT_USE_FILE})

--- a/include/PDecayManager.h
+++ b/include/PDecayManager.h
@@ -27,6 +27,7 @@ class PReaction;
 class PChannel;
 class PParticle;
 class TPythia6;
+class PDecayChannel;
 
 #include "PDistributionManager.h"
 #include "PReaction.h"

--- a/src/PStdModels.cc
+++ b/src/PStdModels.cc
@@ -551,7 +551,7 @@ TObjArray *PStdModels::GetModels(void) {
 			GetParticleTotalWidth(tid[2]) < unstable_width ) 
 			n2 = 0; // too narrow
 		    
-		    int h = makeStaticData()->IsParticleHadron(tid[1])*
+		    int h = makeStaticData()->IsParticleHadron(tid[1])+
 			makeStaticData()->IsParticleHadron(tid[2]);
 
 		    /* Decay of a hadron in 1 stable and 1 unstable product */
@@ -611,8 +611,8 @@ TObjArray *PStdModels::GetModels(void) {
 		} /* END 2 products */
 
 		if ((tid[0] == 3) && (!decay_has_composite)) {
-		    int h=makeStaticData()->IsParticleHadron(tid[1])*
-			makeStaticData()->IsParticleHadron(tid[2])*
+		    int h=makeStaticData()->IsParticleHadron(tid[1])+
+			makeStaticData()->IsParticleHadron(tid[2])+
 			makeStaticData()->IsParticleHadron(tid[3]);
 		    /* 3 decay products */
 


### PR DESCRIPTION
Small CMake improvements:
- Check if the found ROOT version is at least 6.00
- Solve a linker issue on some platforms


Fixed a bug where the wrong decay model was used if not all decay particles are hadrons
(e.g. eta' -> omega g -> pi0 g g, resulting in a delta peak for the omega mass instead of the expected decay width)

Fixed errors compiling the Pluto ROOT dictionary with older GCC versions like GCC5