### PR TITLE
Fix AddChannel parameters to accept constant strings

### DIFF
--- a/include/PDecayChannel.h
+++ b/include/PDecayChannel.h
@@ -62,7 +62,7 @@ class PDecayChannel : public TObject {
     void AddChannel(Double_t w, const char *d1, const char *d2);
     void AddChannel(Double_t w, const char *d1, const char *d2, const char *d3);
     void AddChannel(Double_t w, const char *d1, const char *d2, const char *d3, const char *d4);
-    void AddChannel(Double_t w, Int_t nd, char **ld);
+    void AddChannel(Double_t w, Int_t nd, const char **ld);
 
     // Get the information out of the class ...
     Double_t GetWeight();

--- a/src/PDecayChannel.cc
+++ b/src/PDecayChannel.cc
@@ -329,7 +329,7 @@ void PDecayChannel::AddChannel(Double_t w, const char *d1, const char *d2, const
 // --------------------------------------------------------------------------
 
 // --------------------------------------------------------------------------
-void PDecayChannel::AddChannel(Double_t w, Int_t nd, char **ld) {
+void PDecayChannel::AddChannel(Double_t w, Int_t nd, const char **ld) {
     // The channel describes a decay into nd daughter particles represented by
     // an array of their names ld and branching ratio w.
     if (!Daughters.GetArray()) {


### PR DESCRIPTION
It adds const cv-specifier to the ids parameter to accept also const char literals.
My editor also fixes trailing white spaces.
I will not be able to fix other PR without this being accepted first.